### PR TITLE
feat: Add token optimization and pagination support

### DIFF
--- a/.changeset/clever-bears-approve.md
+++ b/.changeset/clever-bears-approve.md
@@ -1,0 +1,12 @@
+---
+"@shinzolabs/gmail-mcp": minor
+---
+
+Add token optimization features to prevent LLM context window overflow
+
+- Add new `get_message_summary` tool that returns only essential message fields (To, From, Subject, Date, body text) using ~100-200 tokens instead of 1,000-50,000+ tokens
+- Add automatic pagination for `get_message`, `get_message_summary`, and `get_thread` tools with 22,500 token limit per response
+- Include 250-token overlap between paginated chunks for context continuity
+- Add `tokenOffset` parameter for fetching subsequent chunks of large messages/threads
+- Update tool descriptions with context warnings about token usage
+- Add `maxBodyLength` parameter to `get_message_summary` for body-level pagination

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ pnpm i && pnpm build
 #### Managing Messages
 - `list_messages`: List messages with optional filtering
 - `get_message`: Get a specific message
+- `get_message_summary`: Get a concise message summary with essential fields only (recommended for most use cases)
 - `get_attachment`: Get a message attachment
 - `modify_message`: Modify message labels
 - `send_message`: Send an email message to specified recipients


### PR DESCRIPTION
## Summary

This PR adds token optimization features to prevent LLM context window overflow when processing large emails and threads.

## Changes

- **New Tool**: `get_message_summary` - Returns only essential message fields (To, From, Subject, Date, body text) using ~100-200 tokens instead of 1,000-50,000+ tokens
- **Automatic Pagination**: Applied to `get_message`, `get_message_summary`, and `get_thread` with 22,500 token limit per response
- **Context Continuity**: 250-token overlap between paginated chunks
- **New Parameters**:
  - `tokenOffset` - For fetching subsequent chunks of large messages/threads
  - `maxBodyLength` - For body-level pagination in summaries
- **Updated Documentation**: Tool descriptions include context usage warnings

## Problem Solved

Large emails and long thread histories can easily exceed LLM context limits (e.g., a single email can use 10,000+ tokens, threads can exceed 100,000+ tokens). This makes it impossible for AI assistants to process email data effectively.

## Testing

Tested with real Gmail account containing various message types:
- Single messages: 98.2% token reduction with summary tool
- Large messages: Automatic pagination working correctly with proper overlap
- Thread handling: Pagination prevents context overflow

## Changeset

Included changeset for minor version bump per contribution guidelines.