### PR TITLE
Add environment variable support for paths

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,8 @@ import path from 'path'
 import os from 'os'
 
 export const MCP_CONFIG_DIR = process.env.MCP_CONFIG_DIR || path.join(os.homedir(), '.gmail-mcp')
-export const GMAIL_OAUTH_PATH = path.join(MCP_CONFIG_DIR, 'gcp-oauth.keys.json')
-export const GMAIL_CREDENTIALS_PATH = path.join(MCP_CONFIG_DIR, 'credentials.json')
+export const GMAIL_OAUTH_PATH = process.env.GMAIL_OAUTH_PATH || path.join(MCP_CONFIG_DIR, 'gcp-oauth.keys.json')
+export const GMAIL_CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(MCP_CONFIG_DIR, 'credentials.json')
 export const AUTH_SERVER_PORT = process.env.AUTH_SERVER_PORT || 3000
 export const PORT = process.env.PORT || 3000
 export const TELEMETRY_ENABLED = process.env.TELEMETRY_ENABLED || "true"


### PR DESCRIPTION
Allow overriding of file names for path and credentials. This permits multiple servers pointing at differently configured authentication tokens (provided that the ports are set uniquely)

I used to do this with 

https://github.com/GongRzhe/Gmail-MCP-Server

and it allowed me to create a server per email account. Shouldn’t have negative effects as anyone not relying on this wouldn’t have the env vars set