### PR TITLE
Fix EADDRINUSE port conflict between MCP server and auth server

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pnpm i && pnpm build
 
 | Variable                 | Description                                             | Required?                       | Default                              |
 |--------------------------|---------------------------------------------------------|---------------------------------|--------------------------------------|
-| `AUTH_SERVER_PORT`       | Port for the temporary OAuth authentication server      | No                              | `3000`                               |
+| `AUTH_SERVER_PORT`       | Port for the temporary OAuth authentication server      | No                              | `3456`                               |
 | `CLIENT_ID`              | Google API client ID (found in `GMAIL_OAUTH_PATH`)      | Yes if remote server connection | `''`                                 |
 | `CLIENT_SECRET`          | Google API client secret (found in `GMAIL_OAUTH_PATH`)  | Yes if remote server connection | `''`                                 |
 | `GMAIL_CREDENTIALS_PATH` | Path to the user credentials file                       | No                              | `MCP_CONFIG_DIR/credentials.json`    |

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import os from 'os'
 export const MCP_CONFIG_DIR = process.env.MCP_CONFIG_DIR || path.join(os.homedir(), '.gmail-mcp')
 export const GMAIL_OAUTH_PATH = path.join(MCP_CONFIG_DIR, 'gcp-oauth.keys.json')
 export const GMAIL_CREDENTIALS_PATH = path.join(MCP_CONFIG_DIR, 'credentials.json')
-export const AUTH_SERVER_PORT = process.env.AUTH_SERVER_PORT || 3000
+export const AUTH_SERVER_PORT = process.env.AUTH_SERVER_PORT || 3456
 export const PORT = process.env.PORT || 3000
 export const TELEMETRY_ENABLED = process.env.TELEMETRY_ENABLED || "true"
 


### PR DESCRIPTION
## Summary

- Both AUTH_SERVER_PORT and PORT in config.ts default to 3000, causing an EADDRINUSE error when running the auth subcommand while the MCP server is already connected (e.g., via Claude Code or Claude Desktop)
- The MCP server Streamable HTTP transport binds port 3000 via app.listen(PORT), and the OAuth callback server in launchAuthServer() also tries to bind port 3000 via server.listen(AUTH_SERVER_PORT) -- they can never coexist
- Changed AUTH_SERVER_PORT default from 3000 to 3456 so the auth server and MCP server use different ports by default
- Updated README to reflect the new default

## Details

In src/index.ts, the main() function does two things depending on the subcommand:

1. **auth subcommand**: calls launchAuthServer() which binds AUTH_SERVER_PORT (default 3000) for the OAuth2 callback
2. **Normal startup**: binds PORT (default 3000) for the Streamable HTTP transport

Since both default to 3000, users cannot re-authenticate while the MCP server is running without manually setting AUTH_SERVER_PORT to a different value. This is a common pain point since MCP servers typically run persistently in the background.

The fix is minimal: change the AUTH_SERVER_PORT default to 3456. The AUTH_SERVER_PORT env var override still works for users who need a specific port. The OAuth redirect URI in oauth2.ts is already dynamically constructed from AUTH_SERVER_PORT, so no other code changes are needed.

**Note for users with Web Application OAuth credentials**: If your GCP OAuth client is configured as a Web Application (not Desktop app), you will need to add http://localhost:3456/oauth2callback as an authorized redirect URI in GCP Console.

## Test plan

- [x] TypeScript compiles cleanly (npx tsc --noEmit)
- [ ] Run npx @shinzolabs/gmail-mcp (MCP server starts on port 3000)
- [ ] In a separate terminal, run npx @shinzolabs/gmail-mcp auth (auth server starts on port 3456, no EADDRINUSE)
- [ ] Verify OAuth flow completes successfully with the new callback port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default authentication server port from 3000 to 3456.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->