### PR TITLE
fix: only start HTTP server when MCP_HTTP=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ pnpm i && pnpm build
 | `GMAIL_OAUTH_PATH`       | Path to the Google API Client file                      | No                              | `MCP_CONFIG_DIR/gcp-oauth.keys.json` |
 | `MCP_CONFIG_DIR`         | Directory for storing configuration files               | No                              | `~/.gmail-mcp`                       |
 | `REFRESH_TOKEN`          | OAuth refresh token (found in `GMAIL_CREDENTIALS_PATH`) | Yes if remote server connection | `''`                                 |
+| `MCP_HTTP`               | Set to `false` to disable the Streamable HTTP server    | No                              | (enabled)                            |
 | `PORT`                   | Port for Streamable HTTP transport method               | No                              | `3000`                               |
 | `TELEMETRY_ENABLED`      | Enable telemetry                                        | No                              | `true`                               |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1355,9 +1355,14 @@ const main = async () => {
   await stdioServer.connect(transport)
 
   // Streamable HTTP Server (only when explicitly enabled)
-  if (process.env.MCP_HTTP === 'true') {
+  const mcpHttpEnabled = process.env.MCP_HTTP === 'true'
+  if (mcpHttpEnabled) {
     const { app } = createStatefulServer(createServer)
-    app.listen(PORT)
+    app.listen(PORT, () => {
+      process.stderr.write(`[gmail-mcp] HTTP transport enabled on port ${PORT}\n`)
+    })
+  } else {
+    process.stderr.write('[gmail-mcp] HTTP transport disabled (set MCP_HTTP=true to enable)\n')
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1354,9 +1354,11 @@ const main = async () => {
   const transport = new StdioServerTransport()
   await stdioServer.connect(transport)
 
-  // Streamable HTTP Server
-  const { app } = createStatefulServer(createServer)
-  app.listen(PORT)
+  // Streamable HTTP Server (only when explicitly enabled)
+  if (process.env.MCP_HTTP === 'true') {
+    const { app } = createStatefulServer(createServer)
+    app.listen(PORT)
+  }
 }
 
 main()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1354,15 +1354,15 @@ const main = async () => {
   const transport = new StdioServerTransport()
   await stdioServer.connect(transport)
 
-  // Streamable HTTP Server (only when explicitly enabled)
-  const mcpHttpEnabled = process.env.MCP_HTTP === 'true'
-  if (mcpHttpEnabled) {
+  // Streamable HTTP Server (enabled by default; set MCP_HTTP=false to disable)
+  const mcpHttpDisabled = process.env.MCP_HTTP === 'false'
+  if (!mcpHttpDisabled) {
     const { app } = createStatefulServer(createServer)
     app.listen(PORT, () => {
       process.stderr.write(`[gmail-mcp] HTTP transport enabled on port ${PORT}\n`)
     })
   } else {
-    process.stderr.write('[gmail-mcp] HTTP transport disabled (set MCP_HTTP=true to enable)\n')
+    process.stderr.write('[gmail-mcp] HTTP transport disabled (MCP_HTTP=false)\n')
   }
 }
 

--- a/test/README.md
+++ b/test/README.md
@@ -14,6 +14,7 @@ export CLIENT_ID=
 export CLIENT_SECRET=
 export REFRESH_TOKEN=
 export PORT= #For Streamable HTTP transport if 3000 is unavailable
+# Note: HTTP transport is enabled by default. Set MCP_HTTP=false to disable it.
 ```
 
 2. Run the test suite:


### PR DESCRIPTION
## Problem

The Streamable HTTP server starts unconditionally alongside the stdio transport in `main()`, binding to port 3000 by default. This causes `EADDRINUSE` errors when port 3000 is already in use — which is extremely common in development environments (React, Next.js, Express, etc.).

This affects every stdio-based MCP client (Claude Desktop, mcporter, Cursor, etc.) since the HTTP server isn't needed for stdio transport.

## Fix

Make the HTTP server **opt-out** via `MCP_HTTP=false` environment variable. HTTP remains **enabled by default** to preserve backward compatibility with existing container/Docker deployments.

To disable HTTP transport (stdio-only mode):
```bash
MCP_HTTP=false npx @shinzolabs/gmail-mcp
```

Startup mode is logged to stderr for operator visibility:
- `[gmail-mcp] HTTP transport enabled on port 3000`
- `[gmail-mcp] HTTP transport disabled (MCP_HTTP=false)`

## Changes

- `src/index.ts`: Wrap HTTP server startup in opt-out guard (`MCP_HTTP !== 'false'`)
- Add startup-mode logging to stderr for transparency
- No breaking changes — HTTP is still on by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made HTTP server startup configurable via MCP_HTTP so the app can run with or without HTTP enabled.
  * App now logs whether HTTP transport is active; when enabled it reports the listening port, when disabled it logs that HTTP transport is off.

* **Documentation**
  * Added MCP_HTTP documentation and noted default (enabled) and how to disable it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->