### PR TITLE
Fix thread reply formatting: multipart MIME, HTML quoting, header handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createStatefulServer } from "@smithery/sdk/server/stateful.js"
 import { z } from "zod"
 import { google, gmail_v1 } from 'googleapis'
+import crypto from "crypto"
 import fs from "fs"
 import { createOAuth2Client, launchAuthServer, validateCredentials } from "./oauth2.js"
 import { MCP_CONFIG_DIR, PORT, TELEMETRY_ENABLED } from "./config.js"
@@ -117,6 +118,34 @@ const getNestedHistory = (messagePart: MessagePart, level = 1): string => {
   return (messagePart.parts || []).map(p => getNestedHistory(p, level + 1)).filter(p => p).join('\n')
 }
 
+const getNestedHistoryHtml = (messagePart: MessagePart): string => {
+  if (messagePart.mimeType === 'text/html' && messagePart.body?.data) {
+    const { data } = decodedBody(messagePart.body)
+    return data || ''
+  }
+
+  if (messagePart.mimeType === 'text/plain' && messagePart.body?.data) {
+    const { data } = decodedBody(messagePart.body)
+    if (!data) return ''
+    return data.split('\n').map(line => escapeHtml(line)).join('<br>')
+  }
+
+  // Prefer text/html part if available
+  const htmlPart = (messagePart.parts || []).find(p => p.mimeType === 'text/html')
+  if (htmlPart) return getNestedHistoryHtml(htmlPart)
+
+  return (messagePart.parts || []).map(p => getNestedHistoryHtml(p)).filter(p => p).join('')
+}
+
+const escapeHtml = (text: string): string => {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
 const findHeader = (headers: MessagePartHeader[] | undefined, name: string) => {
   if (!headers || !Array.isArray(headers) || !name) return undefined
   return headers.find(h => h?.name?.toLowerCase() === name.toLowerCase())?.value ?? undefined
@@ -159,6 +188,35 @@ const getQuotedContent = (thread: Thread) => {
   }
 
   return quotedContent.join('\n')
+}
+
+const getQuotedContentHtml = (thread: Thread): string => {
+  if (!thread.messages?.length) return ''
+
+  const sentMessages = thread.messages.filter(msg =>
+    msg.labelIds?.includes('SENT') ||
+    (!msg.labelIds?.includes('DRAFT') && findHeader(msg.payload?.headers || [], 'date'))
+  )
+
+  if (!sentMessages.length) return ''
+
+  const lastMessage = sentMessages[sentMessages.length - 1]
+  if (!lastMessage?.payload) return ''
+
+  let attrHtml = ''
+  if (lastMessage.payload.headers) {
+    const fromHeader = findHeader(lastMessage.payload.headers || [], 'from')
+    const dateHeader = findHeader(lastMessage.payload.headers || [], 'date')
+    if (fromHeader && dateHeader) {
+      attrHtml = `<div dir="ltr" class="gmail_attr">On ${escapeHtml(dateHeader)}, ${escapeHtml(fromHeader)} wrote:<br></div>`
+    }
+  }
+
+  const quotedHtml = getNestedHistoryHtml(lastMessage.payload)
+
+  if (!attrHtml && !quotedHtml) return ''
+
+  return `<br><div class="gmail_quote gmail_quote_container">${attrHtml}<blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">${quotedHtml}</blockquote></div>`
 }
 
 const getThreadHeaders = (thread: Thread) => {
@@ -205,33 +263,71 @@ const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) =>
     thread = data
   }
 
-  const message = []
-  if (params.to?.length) message.push(`To: ${wrapTextBody(params.to.join(', '))}`)
-  if (params.cc?.length) message.push(`Cc: ${wrapTextBody(params.cc.join(', '))}`)
-  if (params.bcc?.length) message.push(`Bcc: ${wrapTextBody(params.bcc.join(', '))}`)
+  const headers: string[] = []
+  if (params.to?.length) headers.push(`To: ${params.to.join(', ')}`)
+  if (params.cc?.length) headers.push(`Cc: ${params.cc.join(', ')}`)
+  if (params.bcc?.length) headers.push(`Bcc: ${params.bcc.join(', ')}`)
   if (thread) {
-    message.push(...getThreadHeaders(thread).map(header => wrapTextBody(header)))
+    headers.push(...getThreadHeaders(thread))
   } else if (params.subject) {
-    message.push(`Subject: ${wrapTextBody(params.subject)}`)
+    headers.push(`Subject: ${params.subject}`)
   } else {
-    message.push('Subject: (No Subject)')
+    headers.push('Subject: (No Subject)')
   }
-  message.push('Content-Type: text/plain; charset="UTF-8"')
-  message.push('Content-Transfer-Encoding: quoted-printable')
-  message.push('MIME-Version: 1.0')
-  message.push('')
+  headers.push('MIME-Version: 1.0')
 
-  if (params.body) message.push(wrapTextBody(params.body))
+  const bodyText = params.body || ''
+  const isThreadReply = !!thread
 
-  if (thread) {
-    const quotedContent = getQuotedContent(thread)
+  if (isThreadReply) {
+    // Thread replies use multipart/alternative (text/plain + text/html) to match native Gmail
+    const boundary = `----=_Part_${crypto.randomBytes(16).toString('hex')}`
+    headers.push(`Content-Type: multipart/alternative; boundary="${boundary}"`)
+
+    // Build text/plain part with > quoting
+    let plainBody = bodyText
+    const quotedContent = getQuotedContent(thread!)
     if (quotedContent) {
-      message.push('')
-      message.push(wrapTextBody(quotedContent))
+      plainBody += '\r\n\r\n' + quotedContent
     }
-  }
 
-  return Buffer.from(message.join('\r\n')).toString('base64url').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+    // Build text/html part with Gmail-style blockquote
+    let htmlBody = `<div dir="ltr">${escapeHtml(bodyText).replace(/\n/g, '<br>')}</div>`
+    const quotedHtml = getQuotedContentHtml(thread!)
+    if (quotedHtml) {
+      htmlBody += quotedHtml
+    }
+
+    const message = [
+      ...headers,
+      '',
+      `--${boundary}`,
+      'Content-Type: text/plain; charset="UTF-8"',
+      'Content-Transfer-Encoding: quoted-printable',
+      '',
+      wrapTextBody(plainBody),
+      `--${boundary}`,
+      'Content-Type: text/html; charset="UTF-8"',
+      'Content-Transfer-Encoding: quoted-printable',
+      '',
+      wrapTextBody(htmlBody),
+      `--${boundary}--`
+    ]
+
+    return Buffer.from(message.join('\r\n')).toString('base64url').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  } else {
+    // Non-thread messages remain text/plain for simplicity
+    headers.push('Content-Type: text/plain; charset="UTF-8"')
+    headers.push('Content-Transfer-Encoding: quoted-printable')
+
+    const message = [
+      ...headers,
+      '',
+      wrapTextBody(bodyText)
+    ]
+
+    return Buffer.from(message.join('\r\n')).toString('base64url').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  }
 }
 
 function getConfig(config: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,6 +255,8 @@ const wrapTextBody = (text: string): string => text.split('\n').map(line => {
   return chunks.join('=\n')
 }).join('\n')
 
+const sanitizeHeader = (value: string): string => value.replace(/[\r\n]/g, '')
+
 const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) => {
   let thread: Thread | null = null
   if (params.threadId) {
@@ -264,13 +266,13 @@ const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) =>
   }
 
   const headers: string[] = []
-  if (params.to?.length) headers.push(`To: ${params.to.join(', ')}`)
-  if (params.cc?.length) headers.push(`Cc: ${params.cc.join(', ')}`)
-  if (params.bcc?.length) headers.push(`Bcc: ${params.bcc.join(', ')}`)
+  if (params.to?.length) headers.push(`To: ${params.to.map(sanitizeHeader).join(', ')}`)
+  if (params.cc?.length) headers.push(`Cc: ${params.cc.map(sanitizeHeader).join(', ')}`)
+  if (params.bcc?.length) headers.push(`Bcc: ${params.bcc.map(sanitizeHeader).join(', ')}`)
   if (thread) {
     headers.push(...getThreadHeaders(thread))
   } else if (params.subject) {
-    headers.push(`Subject: ${params.subject}`)
+    headers.push(`Subject: ${sanitizeHeader(params.subject)}`)
   } else {
     headers.push('Subject: (No Subject)')
   }
@@ -303,14 +305,14 @@ const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) =>
       '',
       `--${boundary}`,
       'Content-Type: text/plain; charset="UTF-8"',
-      'Content-Transfer-Encoding: quoted-printable',
+      'Content-Transfer-Encoding: base64',
       '',
-      wrapTextBody(plainBody),
+      Buffer.from(plainBody, 'utf-8').toString('base64'),
       `--${boundary}`,
       'Content-Type: text/html; charset="UTF-8"',
-      'Content-Transfer-Encoding: quoted-printable',
+      'Content-Transfer-Encoding: base64',
       '',
-      wrapTextBody(htmlBody),
+      Buffer.from(htmlBody, 'utf-8').toString('base64'),
       `--${boundary}--`
     ]
 
@@ -318,12 +320,12 @@ const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) =>
   } else {
     // Non-thread messages remain text/plain for simplicity
     headers.push('Content-Type: text/plain; charset="UTF-8"')
-    headers.push('Content-Transfer-Encoding: quoted-printable')
+    headers.push('Content-Transfer-Encoding: base64')
 
     const message = [
       ...headers,
       '',
-      wrapTextBody(bodyText)
+      Buffer.from(bodyText, 'utf-8').toString('base64')
     ]
 
     return Buffer.from(message.join('\r\n')).toString('base64url').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,12 +249,6 @@ const getThreadHeaders = (thread: Thread) => {
   return headers
 }
 
-const wrapTextBody = (text: string): string => text.split('\n').map(line => {
-  if (line.length <= 76) return line
-  const chunks = line.match(/.{1,76}/g) || []
-  return chunks.join('=\n')
-}).join('\n')
-
 const sanitizeHeader = (value: string): string => value.replace(/[\r\n]/g, '')
 
 const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,7 +316,7 @@ const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) =>
       `--${boundary}--`
     ]
 
-    return Buffer.from(message.join('\r\n')).toString('base64url').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+    return Buffer.from(message.join('\r\n')).toString('base64url')
   } else {
     // Non-thread messages remain text/plain for simplicity
     headers.push('Content-Type: text/plain; charset="UTF-8"')
@@ -328,7 +328,7 @@ const constructRawMessage = async (gmail: gmail_v1.Gmail, params: NewMessage) =>
       Buffer.from(bodyText, 'utf-8').toString('base64')
     ]
 
-    return Buffer.from(message.join('\r\n')).toString('base64url').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+    return Buffer.from(message.join('\r\n')).toString('base64url')
   }
 }
 


### PR DESCRIPTION
## Summary

Thread replies sent via `create_draft` and `send_message` are visibly different from native Gmail replies. Recipients can tell the email was not sent from the Gmail UI.

**Before (text/plain only, raw `>` quoting):**

![before](https://github.com/Christian-Sidak/gnizo/releases/download/gmail-mcp-screenshots/gmail-mcp-before.png)

**After (multipart/alternative, HTML blockquotes):**

![after](https://github.com/Christian-Sidak/gnizo/releases/download/gmail-mcp-screenshots/gmail-mcp-after.png)

## Problems fixed

1. **MIME structure**: Replies were `text/plain` only. Native Gmail sends `multipart/alternative` with both `text/plain` and `text/html` parts. Fixed to generate proper multipart MIME for thread replies.

2. **Quoted content**: Used raw `>` prefix characters instead of HTML blockquotes. Fixed with `gmail_quote` class and styled `<blockquote>` matching native Gmail rendering.

3. **Header mangling**: `In-Reply-To` and `References` headers were run through `wrapTextBody()`, which applied quoted-printable encoding (76-char line breaks with `=`). This corrupted Message-IDs and could break thread association. Fixed to only apply body encoding to body content.

4. **MIME boundary**: Uses `crypto.randomBytes` for secure boundary generation.

## What changed

- `constructRawMessage()` now generates `multipart/alternative` when replying in a thread (non-thread messages unchanged)
- New `getQuotedContentHtml()` / `getNestedHistoryHtml()` for Gmail-style HTML blockquotes
- `wrapTextBody()` no longer applied to header values

Fixes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for HTML-formatted quoted messages in threaded email replies with Gmail-style quote formatting.

* **Bug Fixes**
  * Improved email header safety by sanitizing To, Cc, Bcc, and Subject fields to prevent encoding issues in thread replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->