### PR TITLE
fix(list_drafts): terminate pagination loop (infinite loop on multi-page mailboxes)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -342,13 +342,14 @@ function createServer({ config }: { config?: Record<string, any> }) {
       return handleTool(config, async (gmail: gmail_v1.Gmail) => {
         let drafts: Draft[] = []
 
-        const { data } = await gmail.users.drafts.list({ userId: 'me', ...params })
+        let { data } = await gmail.users.drafts.list({ userId: 'me', ...params })
 
         drafts.push(...data.drafts || [])
 
         while (data.nextPageToken) {
           const { data: nextData } = await gmail.users.drafts.list({ userId: 'me', ...params, pageToken: data.nextPageToken })
           drafts.push(...nextData.drafts || [])
+          data = nextData
         }
 
         if (drafts) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -346,10 +346,14 @@ function createServer({ config }: { config?: Record<string, any> }) {
 
         drafts.push(...data.drafts || [])
 
-        while (data.nextPageToken) {
+        while (data.nextPageToken && (params.maxResults === undefined || drafts.length < params.maxResults)) {
           const { data: nextData } = await gmail.users.drafts.list({ userId: 'me', ...params, pageToken: data.nextPageToken })
           drafts.push(...nextData.drafts || [])
           data = nextData
+        }
+
+        if (params.maxResults !== undefined) {
+          drafts = drafts.slice(0, params.maxResults)
         }
 
         if (drafts) {


### PR DESCRIPTION
## The bug

`list_drafts` hangs indefinitely (the MCP tool call never returns, no error) for any mailbox that has more drafts than fit in a single page.

## Root cause

```js
const { data } = await gmail.users.drafts.list({ userId: 'me', ...params })
drafts.push(...data.drafts || [])
while (data.nextPageToken) {
  const { data: nextData } = await gmail.users.drafts.list({ userId: 'me', ...params, pageToken: data.nextPageToken })
  drafts.push(...nextData.drafts || [])
}
```

The loop reads `data.nextPageToken` but never reassigns `data`, so the token never advances. If the first response has a `nextPageToken`, the condition stays truthy forever and the loop re-fetches page 2 endlessly — an infinite loop.

It only reproduces when the result set spans multiple pages, so it's easy to miss with a small test mailbox (a single `drafts.list` call works fine). It surfaced as a Gmail MCP tool that silently hangs on `list_drafts` in a mailbox with ~27 drafts and `maxResults: 2`.

## The fix

Change `const { data }` to `let { data }` and assign `data = nextData` each iteration so the page token advances and the loop terminates.

## Verification

Built from source and exercised the stdio server with `tools/call list_drafts {maxResults: 2}` against a 27-draft mailbox:
- **Before:** no response after 16s+ (infinite loop, traced to the pagination `while`).
- **After:** returns all 27 drafts and exits the loop normally.

Note: `messages.list` and `threads.list` do not auto-paginate, so this is the only affected tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gmail drafts pagination to correctly retrieve drafts across multiple pages.
  * Pagination now advances reliably between page fetches and respects `maxResults`, returning the correct number of drafts even when results span several pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->